### PR TITLE
fix: onDidSaveTextDocument notification method name

### DIFF
--- a/packages/amazonq/src/lsp/client.ts
+++ b/packages/amazonq/src/lsp/client.ts
@@ -327,7 +327,7 @@ async function onLanguageServerReady(
             } as RenameFilesParams)
         }),
         vscode.workspace.onDidSaveTextDocument((e) => {
-            client.sendNotification('workspace/didSaveTextDocument', {
+            client.sendNotification('textDocument/didSave', {
                 textDocument: {
                     uri: e.uri.fsPath,
                 },


### PR DESCRIPTION
## Problem


## Solution


---

- Treat all work as PUBLIC. Private `feature/x` branches will not be squash-merged at release time.
- Your code changes must meet the guidelines in [CONTRIBUTING.md](https://github.com/aws/aws-toolkit-vscode/blob/master/CONTRIBUTING.md#guidelines).
- License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
